### PR TITLE
AWS DDB Generation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,3 @@
 {
-  "enabledPlugins": {
-    "massdriver@massdriver-skills": true
-  }
+  "enabledPlugins": {}
 }

--- a/artifact-definitions/aws-dynamodb-stream/massdriver.yaml
+++ b/artifact-definitions/aws-dynamodb-stream/massdriver.yaml
@@ -1,0 +1,59 @@
+name: aws-dynamodb-stream
+label: AWS DynamoDB Stream
+
+schema:
+  title: AWS DynamoDB Stream
+  description: AWS DynamoDB Stream artifact for event-driven architectures.
+  type: object
+  required:
+    - data
+    - specs
+  properties:
+    data:
+      title: Artifact Data
+      type: object
+      required:
+        - infrastructure
+      properties:
+        infrastructure:
+          title: Infrastructure
+          type: object
+          required:
+            - arn
+            - table_arn
+          properties:
+            arn:
+              title: Stream ARN
+              description: Amazon Resource Name of the DynamoDB stream.
+              type: string
+            table_arn:
+              title: Table ARN
+              description: ARN of the parent DynamoDB table.
+              type: string
+        security:
+          title: Security
+          type: object
+          properties:
+            iam:
+              title: IAM Policies
+              description: IAM policies for stream access.
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  policy_arn:
+                    title: Policy ARN
+                    description: ARN of the IAM policy.
+                    type: string
+    specs:
+      title: Artifact Specs
+      type: object
+      properties:
+        aws:
+          title: AWS Specs
+          type: object
+          properties:
+            region:
+              title: Region
+              description: AWS region where the stream is located.
+              type: string

--- a/artifact-definitions/aws-dynamodb-table/massdriver.yaml
+++ b/artifact-definitions/aws-dynamodb-table/massdriver.yaml
@@ -1,0 +1,59 @@
+name: aws-dynamodb-table
+label: AWS DynamoDB Table
+
+schema:
+  title: AWS DynamoDB Table
+  description: AWS DynamoDB table artifact containing table ARN, name, and IAM policies for access.
+  type: object
+  required:
+    - data
+    - specs
+  properties:
+    data:
+      title: Artifact Data
+      type: object
+      required:
+        - infrastructure
+      properties:
+        infrastructure:
+          title: Infrastructure
+          type: object
+          required:
+            - arn
+            - table_name
+          properties:
+            arn:
+              title: Table ARN
+              description: Amazon Resource Name of the DynamoDB table.
+              type: string
+            table_name:
+              title: Table Name
+              description: Name of the DynamoDB table.
+              type: string
+        security:
+          title: Security
+          type: object
+          properties:
+            iam:
+              title: IAM Policies
+              description: IAM policies for table access.
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  policy_arn:
+                    title: Policy ARN
+                    description: ARN of the IAM policy.
+                    type: string
+    specs:
+      title: Artifact Specs
+      type: object
+      properties:
+        aws:
+          title: AWS Specs
+          type: object
+          properties:
+            region:
+              title: Region
+              description: AWS region where the table is deployed.
+              type: string

--- a/bundles/aws-ddb/massdriver.yaml
+++ b/bundles/aws-ddb/massdriver.yaml
@@ -1,0 +1,410 @@
+schema: draft-07
+name: aws-ddb
+description: Self-service DynamoDB tables for application developers. Supports user sessions, feature flags, application state, and other NoSQL workloads with flexible key design, secondary indexes, and optional DynamoDB Streams.
+source_url: https://github.com/massdriver-cloud/massdriver-catalog/tree/main/bundles/aws-ddb
+version: 0.0.1
+
+params:
+  required:
+    - region
+    - table
+    - billing
+  examples:
+    - __name: Development
+      region: us-east-1
+      table:
+        name: my-table
+        hash_key:
+          name: pk
+          type: S
+      billing:
+        mode: PAY_PER_REQUEST
+      backup:
+        point_in_time_recovery: false
+        deletion_protection: false
+      stream:
+        enabled: false
+    - __name: Production
+      region: us-east-1
+      table:
+        name: my-table
+        hash_key:
+          name: pk
+          type: S
+        range_key:
+          name: sk
+          type: S
+      billing:
+        mode: PAY_PER_REQUEST
+      backup:
+        point_in_time_recovery: true
+        deletion_protection: true
+      stream:
+        enabled: false
+    - __name: Event-Driven
+      region: us-east-1
+      table:
+        name: my-table
+        hash_key:
+          name: pk
+          type: S
+        range_key:
+          name: sk
+          type: S
+      billing:
+        mode: PAY_PER_REQUEST
+      backup:
+        point_in_time_recovery: true
+        deletion_protection: true
+      stream:
+        enabled: true
+        view_type: NEW_AND_OLD_IMAGES
+  properties:
+    region:
+      title: AWS Region
+      description: AWS region to deploy the DynamoDB table.
+      type: string
+      $md.immutable: true
+      default: us-east-1
+      enum:
+        - us-east-1
+        - us-east-2
+        - us-west-1
+        - us-west-2
+        - eu-west-1
+        - eu-west-2
+        - eu-central-1
+        - ap-southeast-1
+        - ap-southeast-2
+        - ap-northeast-1
+    table:
+      title: Table Configuration
+      type: object
+      required:
+        - name
+        - hash_key
+      properties:
+        name:
+          title: Table Name
+          description: Name of the DynamoDB table. Must be unique within the AWS account and region.
+          type: string
+          pattern: "^[a-zA-Z0-9._-]{3,255}$"
+          $md.immutable: true
+        hash_key:
+          title: Partition Key
+          description: The partition (hash) key for the table. This is the primary key attribute.
+          type: object
+          required:
+            - name
+            - type
+          properties:
+            name:
+              title: Attribute Name
+              description: Name of the partition key attribute.
+              type: string
+              pattern: "^[a-zA-Z][a-zA-Z0-9_]{0,254}$"
+            type:
+              title: Attribute Type
+              description: Data type of the partition key.
+              type: string
+              enum:
+                - S
+                - N
+                - B
+              enumNames:
+                - String (S)
+                - Number (N)
+                - Binary (B)
+        range_key:
+          title: Sort Key (Optional)
+          description: Optional sort (range) key for composite primary keys. Enables range queries within a partition.
+          type: object
+          properties:
+            name:
+              title: Attribute Name
+              description: Name of the sort key attribute.
+              type: string
+              pattern: "^[a-zA-Z][a-zA-Z0-9_]{0,254}$"
+            type:
+              title: Attribute Type
+              description: Data type of the sort key.
+              type: string
+              enum:
+                - S
+                - N
+                - B
+              enumNames:
+                - String (S)
+                - Number (N)
+                - Binary (B)
+    billing:
+      title: Billing Configuration
+      type: object
+      required:
+        - mode
+      properties:
+        mode:
+          title: Billing Mode
+          description: |
+            PAY_PER_REQUEST (on-demand) scales automatically and charges per request.
+            PROVISIONED requires capacity planning but offers predictable costs.
+          type: string
+          default: PAY_PER_REQUEST
+          enum:
+            - PAY_PER_REQUEST
+            - PROVISIONED
+        provisioned:
+          title: Provisioned Capacity
+          description: Required when using PROVISIONED billing mode.
+          type: object
+          properties:
+            read_capacity:
+              title: Read Capacity Units
+              description: Number of read capacity units (RCUs). 1 RCU = 1 strongly consistent read/sec for items up to 4KB.
+              type: integer
+              minimum: 1
+              maximum: 40000
+              default: 5
+            write_capacity:
+              title: Write Capacity Units
+              description: Number of write capacity units (WCUs). 1 WCU = 1 write/sec for items up to 1KB.
+              type: integer
+              minimum: 1
+              maximum: 40000
+              default: 5
+      dependencies:
+        mode:
+          oneOf:
+            - properties:
+                mode:
+                  const: PAY_PER_REQUEST
+            - properties:
+                mode:
+                  const: PROVISIONED
+                provisioned:
+                  required:
+                    - read_capacity
+                    - write_capacity
+              required:
+                - provisioned
+    indexes:
+      title: Secondary Indexes
+      type: object
+      properties:
+        global:
+          title: Global Secondary Indexes (GSI)
+          description: GSIs allow queries on non-primary key attributes. Each GSI has its own capacity settings.
+          type: array
+          default: []
+          maxItems: 20
+          items:
+            type: object
+            required:
+              - name
+              - hash_key
+            properties:
+              name:
+                title: Index Name
+                type: string
+                pattern: "^[a-zA-Z0-9._-]{3,255}$"
+              hash_key:
+                title: Hash Key
+                type: object
+                required:
+                  - name
+                  - type
+                properties:
+                  name:
+                    title: Attribute Name
+                    type: string
+                  type:
+                    title: Type
+                    type: string
+                    enum:
+                      - S
+                      - N
+                      - B
+              range_key:
+                title: Range Key (Optional)
+                type: object
+                properties:
+                  name:
+                    title: Attribute Name
+                    type: string
+                  type:
+                    title: Type
+                    type: string
+                    enum:
+                      - S
+                      - N
+                      - B
+              projection_type:
+                title: Projection Type
+                description: Which attributes to project into the index.
+                type: string
+                default: ALL
+                enum:
+                  - ALL
+                  - KEYS_ONLY
+                  - INCLUDE
+              non_key_attributes:
+                title: Non-Key Attributes
+                description: Attributes to include when projection_type is INCLUDE.
+                type: array
+                items:
+                  type: string
+        local:
+          title: Local Secondary Indexes (LSI)
+          description: LSIs share capacity with the table and must have the same hash key. Can only be created at table creation time.
+          type: array
+          default: []
+          maxItems: 5
+          items:
+            type: object
+            required:
+              - name
+              - range_key
+            properties:
+              name:
+                title: Index Name
+                type: string
+                pattern: "^[a-zA-Z0-9._-]{3,255}$"
+              range_key:
+                title: Range Key
+                type: object
+                required:
+                  - name
+                  - type
+                properties:
+                  name:
+                    title: Attribute Name
+                    type: string
+                  type:
+                    title: Type
+                    type: string
+                    enum:
+                      - S
+                      - N
+                      - B
+              projection_type:
+                title: Projection Type
+                type: string
+                default: ALL
+                enum:
+                  - ALL
+                  - KEYS_ONLY
+                  - INCLUDE
+              non_key_attributes:
+                title: Non-Key Attributes
+                type: array
+                items:
+                  type: string
+    backup:
+      title: Backup & Recovery
+      type: object
+      properties:
+        point_in_time_recovery:
+          title: Point-in-Time Recovery
+          description: Enable continuous backups and point-in-time recovery. Recommended for production tables.
+          type: boolean
+          default: false
+        deletion_protection:
+          title: Deletion Protection
+          description: Prevent accidental table deletion. Must be explicitly disabled before deleting.
+          type: boolean
+          default: false
+    stream:
+      title: DynamoDB Streams
+      type: object
+      properties:
+        enabled:
+          title: Enable Streams
+          description: Enable DynamoDB Streams for change data capture and event-driven architectures.
+          type: boolean
+          default: false
+        view_type:
+          title: Stream View Type
+          description: What data to include in stream records.
+          type: string
+          default: NEW_AND_OLD_IMAGES
+          enum:
+            - KEYS_ONLY
+            - NEW_IMAGE
+            - OLD_IMAGE
+            - NEW_AND_OLD_IMAGES
+          enumNames:
+            - Keys Only
+            - New Image
+            - Old Image
+            - New and Old Images
+      dependencies:
+        enabled:
+          oneOf:
+            - properties:
+                enabled:
+                  const: false
+            - properties:
+                enabled:
+                  const: true
+                view_type:
+                  type: string
+              required:
+                - view_type
+
+connections:
+  required:
+    - aws_authentication
+  properties:
+    aws_authentication:
+      $ref: aws-iam-role
+      title: AWS Authentication
+
+artifacts:
+  required:
+    - table
+  properties:
+    table:
+      $ref: aws-dynamodb-table
+      title: DynamoDB Table
+    stream:
+      $ref: aws-dynamodb-stream
+      title: DynamoDB Stream
+
+steps:
+  - path: src
+    provisioner: opentofu:1.10
+    config:
+      checkov:
+        enable: true
+        halt_on_failure: '.params.md_metadata.default_tags["md-target"] == "production"'
+
+ui:
+  ui:order:
+    - region
+    - table
+    - billing
+    - indexes
+    - backup
+    - stream
+    - "*"
+  table:
+    ui:order:
+      - name
+      - hash_key
+      - range_key
+  billing:
+    ui:order:
+      - mode
+      - provisioned
+  indexes:
+    ui:order:
+      - global
+      - local
+  backup:
+    ui:order:
+      - point_in_time_recovery
+      - deletion_protection
+  stream:
+    ui:order:
+      - enabled
+      - view_type

--- a/bundles/aws-ddb/src/.checkov.yml
+++ b/bundles/aws-ddb/src/.checkov.yml
@@ -1,0 +1,6 @@
+skip-check:
+  # LOW: AWS managed encryption is sufficient for most use cases.
+  # Using a Customer Managed Key (CMK) adds operational overhead without
+  # significant security benefit for typical application workloads.
+  # For regulatory requirements needing CMK, users can fork the bundle.
+  - CKV_AWS_119

--- a/bundles/aws-ddb/src/_massdriver_variables.tf
+++ b/bundles/aws-ddb/src/_massdriver_variables.tf
@@ -1,0 +1,100 @@
+// Auto-generated variable declarations from massdriver.yaml
+variable "aws_authentication" {
+  type = object({
+    arn         = string
+    external_id = optional(string)
+  })
+}
+variable "backup" {
+  type = object({
+    deletion_protection    = optional(bool)
+    point_in_time_recovery = optional(bool)
+  })
+  default = null
+}
+variable "billing" {
+  type = object({
+    mode = string
+    provisioned = optional(object({
+      read_capacity  = optional(number)
+      write_capacity = optional(number)
+    }))
+  })
+}
+variable "indexes" {
+  type = object({
+    global = optional(list(object({
+      hash_key = object({
+        name = string
+        type = string
+      })
+      name               = string
+      non_key_attributes = optional(list(string))
+      projection_type    = optional(string)
+      range_key = optional(object({
+        name = optional(string)
+        type = optional(string)
+      }))
+    })))
+    local = optional(list(object({
+      name               = string
+      non_key_attributes = optional(list(string))
+      projection_type    = optional(string)
+      range_key = object({
+        name = string
+        type = string
+      })
+    })))
+  })
+  default = null
+}
+variable "md_metadata" {
+  type = object({
+    default_tags = object({
+      managed-by  = string
+      md-manifest = string
+      md-package  = string
+      md-project  = string
+      md-target   = string
+    })
+    deployment = object({
+      id = string
+    })
+    name_prefix = string
+    observability = object({
+      alarm_webhook_url = string
+    })
+    package = object({
+      created_at             = string
+      deployment_enqueued_at = string
+      previous_status        = string
+      updated_at             = string
+    })
+    target = object({
+      contact_email = string
+    })
+  })
+}
+variable "region" {
+  type = string
+}
+variable "stream" {
+  type = object({
+    enabled   = optional(bool)
+    view_type = optional(string)
+  })
+  default = null
+}
+variable "table" {
+  type = object({
+    hash_key = object({
+      name = string
+      type = string
+    })
+    name = string
+    range_key = optional(object({
+      name = optional(string)
+      type = optional(string)
+    }))
+  })
+}

--- a/bundles/aws-ddb/src/artifacts.tf
+++ b/bundles/aws-ddb/src/artifacts.tf
@@ -1,0 +1,55 @@
+resource "massdriver_artifact" "table" {
+  field = "table"
+  name  = "DynamoDB Table ${var.md_metadata.name_prefix}"
+
+  artifact = jsonencode({
+    data = {
+      infrastructure = {
+        arn        = aws_dynamodb_table.main.arn
+        table_name = aws_dynamodb_table.main.name
+      }
+      security = {
+        iam = {
+          read = {
+            policy_arn = aws_iam_policy.read.arn
+          }
+          write = {
+            policy_arn = aws_iam_policy.write.arn
+          }
+        }
+      }
+    }
+    specs = {
+      aws = {
+        region = var.region
+      }
+    }
+  })
+}
+
+resource "massdriver_artifact" "stream" {
+  count = try(var.stream.enabled, false) ? 1 : 0
+  field = "stream"
+  name  = "DynamoDB Stream ${var.md_metadata.name_prefix}"
+
+  artifact = jsonencode({
+    data = {
+      infrastructure = {
+        arn       = aws_dynamodb_table.main.stream_arn
+        table_arn = aws_dynamodb_table.main.arn
+      }
+      security = {
+        iam = {
+          read = {
+            policy_arn = aws_iam_policy.stream[0].arn
+          }
+        }
+      }
+    }
+    specs = {
+      aws = {
+        region = var.region
+      }
+    }
+  })
+}

--- a/bundles/aws-ddb/src/main.tf
+++ b/bundles/aws-ddb/src/main.tf
@@ -1,0 +1,220 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    massdriver = {
+      source  = "massdriver-cloud/massdriver"
+      version = "~> 1.3"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+  assume_role {
+    role_arn    = var.aws_authentication.arn
+    external_id = try(var.aws_authentication.external_id, null)
+  }
+  default_tags {
+    tags = var.md_metadata.default_tags
+  }
+}
+
+locals {
+  table_name = var.table.name
+
+  # Build attribute definitions from keys and indexes
+  hash_key_attr = {
+    name = var.table.hash_key.name
+    type = var.table.hash_key.type
+  }
+
+  range_key_attr = var.table.range_key != null && try(var.table.range_key.name, null) != null ? {
+    name = var.table.range_key.name
+    type = var.table.range_key.type
+  } : null
+
+  gsi_attrs = [
+    for gsi in try(var.indexes.global, []) : [
+      { name = gsi.hash_key.name, type = gsi.hash_key.type },
+      gsi.range_key != null && try(gsi.range_key.name, null) != null ? { name = gsi.range_key.name, type = gsi.range_key.type } : null
+    ]
+  ]
+
+  lsi_attrs = [
+    for lsi in try(var.indexes.local, []) : {
+      name = lsi.range_key.name
+      type = lsi.range_key.type
+    }
+  ]
+
+  # Flatten and deduplicate attributes
+  all_attrs_raw = concat(
+    [local.hash_key_attr],
+    local.range_key_attr != null ? [local.range_key_attr] : [],
+    flatten(local.gsi_attrs),
+    local.lsi_attrs
+  )
+
+  all_attrs = [
+    for attr in distinct([for a in local.all_attrs_raw : a if a != null]) : attr
+  ]
+
+  # Deduplicate by name (keep first occurrence)
+  attr_names_seen = {}
+  unique_attrs = [
+    for attr in local.all_attrs : attr
+    if !contains(keys(local.attr_names_seen), attr.name) && can(local.attr_names_seen[attr.name] == attr.name ? false : true)
+  ]
+}
+
+resource "aws_dynamodb_table" "main" {
+  name         = local.table_name
+  billing_mode = var.billing.mode
+  hash_key     = var.table.hash_key.name
+  range_key    = try(var.table.range_key.name, null)
+
+  # Read/write capacity for provisioned mode
+  read_capacity  = var.billing.mode == "PROVISIONED" ? var.billing.provisioned.read_capacity : null
+  write_capacity = var.billing.mode == "PROVISIONED" ? var.billing.provisioned.write_capacity : null
+
+  # Attribute definitions
+  dynamic "attribute" {
+    for_each = { for attr in local.all_attrs : attr.name => attr }
+    content {
+      name = attribute.value.name
+      type = attribute.value.type
+    }
+  }
+
+  # Global Secondary Indexes
+  dynamic "global_secondary_index" {
+    for_each = try(var.indexes.global, [])
+    content {
+      name               = global_secondary_index.value.name
+      hash_key           = global_secondary_index.value.hash_key.name
+      range_key          = try(global_secondary_index.value.range_key.name, null)
+      projection_type    = try(global_secondary_index.value.projection_type, "ALL")
+      non_key_attributes = try(global_secondary_index.value.projection_type, "ALL") == "INCLUDE" ? global_secondary_index.value.non_key_attributes : null
+
+      # GSI capacity for provisioned mode
+      read_capacity  = var.billing.mode == "PROVISIONED" ? var.billing.provisioned.read_capacity : null
+      write_capacity = var.billing.mode == "PROVISIONED" ? var.billing.provisioned.write_capacity : null
+    }
+  }
+
+  # Local Secondary Indexes
+  dynamic "local_secondary_index" {
+    for_each = try(var.indexes.local, [])
+    content {
+      name               = local_secondary_index.value.name
+      range_key          = local_secondary_index.value.range_key.name
+      projection_type    = try(local_secondary_index.value.projection_type, "ALL")
+      non_key_attributes = try(local_secondary_index.value.projection_type, "ALL") == "INCLUDE" ? local_secondary_index.value.non_key_attributes : null
+    }
+  }
+
+  # DynamoDB Streams
+  stream_enabled   = try(var.stream.enabled, false)
+  stream_view_type = try(var.stream.enabled, false) ? try(var.stream.view_type, "NEW_AND_OLD_IMAGES") : null
+
+  # Point-in-time recovery
+  point_in_time_recovery {
+    enabled = try(var.backup.point_in_time_recovery, false)
+  }
+
+  # Server-side encryption with AWS managed key
+  server_side_encryption {
+    enabled = true
+  }
+
+  # Deletion protection
+  deletion_protection_enabled = try(var.backup.deletion_protection, false)
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# IAM policy for read access
+resource "aws_iam_policy" "read" {
+  name        = "${var.md_metadata.name_prefix}-ddb-read"
+  description = "Read access to DynamoDB table ${local.table_name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadTable"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:BatchGetItem",
+          "dynamodb:Query",
+          "dynamodb:Scan",
+          "dynamodb:DescribeTable",
+          "dynamodb:DescribeTimeToLive"
+        ]
+        Resource = [
+          aws_dynamodb_table.main.arn,
+          "${aws_dynamodb_table.main.arn}/index/*"
+        ]
+      }
+    ]
+  })
+}
+
+# IAM policy for write access
+resource "aws_iam_policy" "write" {
+  name        = "${var.md_metadata.name_prefix}-ddb-write"
+  description = "Write access to DynamoDB table ${local.table_name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "WriteTable"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:BatchWriteItem"
+        ]
+        Resource = [
+          aws_dynamodb_table.main.arn,
+          "${aws_dynamodb_table.main.arn}/index/*"
+        ]
+      }
+    ]
+  })
+}
+
+# IAM policy for stream access (when enabled)
+resource "aws_iam_policy" "stream" {
+  count       = try(var.stream.enabled, false) ? 1 : 0
+  name        = "${var.md_metadata.name_prefix}-ddb-stream"
+  description = "Stream access to DynamoDB table ${local.table_name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadStream"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetRecords",
+          "dynamodb:GetShardIterator",
+          "dynamodb:DescribeStream",
+          "dynamodb:ListStreams"
+        ]
+        Resource = [
+          aws_dynamodb_table.main.stream_arn
+        ]
+      }
+    ]
+  })
+}


### PR DESCRIPTION
> /massdriver I want to create a new DynamoDB bundle for application developers to self-service their own tables. The use case is developers who need NoSQL storage for their applications - things like user sessions, feature flags, application state, etc.
> 
> Key requirements:
> - Developers should be able to configure their own tables, GSIs, and LSIs
> - Support for DynamoDB Streams when they need event-driven architectures
> - On-demand vs provisioned capacity modes
> - Point-in-time recovery and backup options
> 
> I have a environment called "md-test" that has AWS credentials attached.