### PR TITLE
One shot DynamoDB Self-Service OpenTofu bundle with Checkov compliance via Massdriver Agentic Harness + Claude Code

### DIFF
--- a/bundles/aws-dynamodb-table/massdriver.yaml
+++ b/bundles/aws-dynamodb-table/massdriver.yaml
@@ -1,0 +1,172 @@
+name: aws-dynamodb-table
+description: "AWS DynamoDB table with encryption at rest, PITR recovery, and deletion protection hardcoded for compliance."
+source_url: https://github.com/YOUR_ORG/massdriver-catalog/tree/main/bundles/aws-dynamodb-table
+version: 0.1.0
+
+params:
+  required:
+    - region
+    - table_name
+    - hash_key
+    - billing_mode
+  properties:
+    region:
+      type: string
+      title: AWS Region
+      description: AWS region where the table will be created. Cannot be changed after creation.
+      $md.immutable: true
+      enum:
+        - us-east-1
+        - us-east-2
+        - us-west-1
+        - us-west-2
+        - ca-central-1
+        - eu-west-1
+        - eu-west-2
+        - eu-central-1
+        - ap-northeast-1
+        - ap-northeast-2
+        - ap-southeast-1
+        - ap-southeast-2
+        - ap-south-1
+        - sa-east-1
+    table_name:
+      type: string
+      title: Table Name
+      description: Name of the DynamoDB table. Cannot be changed after creation.
+      $md.immutable: true
+      minLength: 3
+      maxLength: 255
+      pattern: "^[a-zA-Z0-9_.-]{3,255}$"
+    hash_key:
+      type: string
+      title: Hash Key (Partition Key)
+      description: Attribute name for the partition key. Cannot be changed after creation.
+      $md.immutable: true
+      minLength: 1
+      maxLength: 255
+    hash_key_type:
+      type: string
+      title: Hash Key Type
+      description: Data type of the partition key. Cannot be changed after creation.
+      $md.immutable: true
+      default: "S"
+      enum:
+        - "S"
+        - "N"
+        - "B"
+      enumNames:
+        - "String (S)"
+        - "Number (N)"
+        - "Binary (B)"
+    range_key:
+      type: string
+      title: Range Key (Sort Key)
+      description: Optional sort key attribute name. Cannot be changed after creation.
+      $md.immutable: true
+      minLength: 1
+      maxLength: 255
+    range_key_type:
+      type: string
+      title: Range Key Type
+      description: Data type of the sort key. Only applies when Range Key is set. Cannot be changed after creation.
+      $md.immutable: true
+      default: "S"
+      enum:
+        - "S"
+        - "N"
+        - "B"
+      enumNames:
+        - "String (S)"
+        - "Number (N)"
+        - "Binary (B)"
+    billing_mode:
+      type: string
+      title: Billing Mode
+      description: "PAY_PER_REQUEST scales automatically w/ no capacity planning. PROVISIONED offers lower cost at high or steady traffic but requires capacity units. Immutable."
+      $md.immutable: true
+      default: "PAY_PER_REQUEST"
+      enum:
+        - "PAY_PER_REQUEST"
+        - "PROVISIONED"
+    read_capacity:
+      type: integer
+      title: Read Capacity Units
+      description: Provisioned read throughput (only used when Billing Mode is PROVISIONED).
+      default: 5
+      minimum: 1
+      maximum: 40000
+    write_capacity:
+      type: integer
+      title: Write Capacity Units
+      description: Provisioned write throughput (only used when Billing Mode is PROVISIONED).
+      default: 5
+      minimum: 1
+      maximum: 40000
+    enable_streams:
+      type: boolean
+      title: Enable DynamoDB Streams
+      description: Capture item-level changes as a stream for Lambda or other consumers.
+      default: false
+    stream_view_type:
+      type: string
+      title: Stream View Type
+      description: What data is written to the stream. Only used when streams are enabled.
+      default: "NEW_AND_OLD_IMAGES"
+      enum:
+        - "KEYS_ONLY"
+        - "NEW_IMAGE"
+        - "OLD_IMAGE"
+        - "NEW_AND_OLD_IMAGES"
+
+  examples:
+    - __name: "Development"
+      region: us-east-1
+      table_name: my-table
+      hash_key: pk
+      hash_key_type: "S"
+      billing_mode: "PAY_PER_REQUEST"
+      enable_streams: false
+    - __name: "Production"
+      region: us-east-1
+      table_name: my-table
+      hash_key: pk
+      hash_key_type: "S"
+      billing_mode: "PAY_PER_REQUEST"
+      enable_streams: true
+      stream_view_type: "NEW_AND_OLD_IMAGES"
+
+connections:
+  required:
+    - aws_authentication
+  properties:
+    aws_authentication:
+      $ref: aws-iam-role
+      title: AWS Authentication
+
+artifacts:
+  required:
+    - table
+  properties:
+    table:
+      $ref: dynamodb
+      title: DynamoDB Table
+
+steps:
+  - path: src
+    provisioner: opentofu:1.10
+
+ui:
+  ui:order:
+    - region
+    - table_name
+    - hash_key
+    - hash_key_type
+    - range_key
+    - range_key_type
+    - billing_mode
+    - read_capacity
+    - write_capacity
+    - enable_streams
+    - stream_view_type
+    - "*"

--- a/bundles/aws-dynamodb-table/operator.md
+++ b/bundles/aws-dynamodb-table/operator.md
@@ -1,0 +1,56 @@
+# aws-dynamodb-table Operator Guide
+
+## Overview
+
+This bundle provisions an AWS DynamoDB table with the following compliance settings hardcoded (non-configurable):
+
+| Setting | Value | Checkov Check |
+|---|---|---|
+| Server-side encryption | Enabled (AWS-managed key) | CKV_AWS_28 |
+| Point-in-time recovery | Enabled | CKV2_AWS_16 |
+| Deletion protection | Enabled | CKV2_AWS_118 |
+
+## Immutable Fields
+
+The following fields cannot be changed after the table is created without destroying and recreating it:
+
+- **Region** — DynamoDB tables are regional resources
+- **Table Name** — changing the name creates a new table
+- **Hash Key** and **Hash Key Type** — the partition key is the table's primary identity
+- **Range Key** and **Range Key Type** — the sort key is part of the key schema
+- **Billing Mode** — changing between PAY_PER_REQUEST and PROVISIONED requires recreation
+
+Massdriver will warn operators before allowing changes to these fields.
+
+## Billing Mode
+
+- **PAY_PER_REQUEST** (default): No capacity planning required. Cost scales linearly with request volume. Best for variable or unpredictable workloads.
+- **PROVISIONED**: Fixed capacity in read/write capacity units (RCU/WCU). Lower cost at high or steady throughput. Requires capacity planning.
+
+## IAM Policies
+
+The bundle produces two IAM policies surfaced on the artifact:
+
+| Policy | Permissions |
+|---|---|
+| Read Only | GetItem, BatchGetItem, Query, Scan, DescribeTable |
+| Read / Write | All Read Only + PutItem, UpdateItem, DeleteItem, BatchWriteItem, ConditionCheckItem |
+
+Consumers should attach the appropriate policy to their execution role.
+
+## DynamoDB Streams
+
+When enabled, streams capture a time-ordered sequence of item-level changes. The stream ARN is published on the artifact. Supported view types:
+
+- `KEYS_ONLY` — only key attributes
+- `NEW_IMAGE` — the item after modification
+- `OLD_IMAGE` — the item before modification
+- `NEW_AND_OLD_IMAGES` (default) — both before and after
+
+## Deletion Protection
+
+Deletion protection is hardcoded to `true`. To decommission a table you must first disable deletion protection in the AWS Console or via CLI, then run `mass pkg destroy`.
+
+## Skipped Checks
+
+`CKV_AWS_119` (customer-managed KMS) is intentionally skipped. AWS-managed SSE satisfies most compliance requirements. If your organization requires a customer-managed KMS key, fork this bundle and add the `kms_master_key_id` argument to the `server_side_encryption` block.

--- a/bundles/aws-dynamodb-table/src/.checkov.yml
+++ b/bundles/aws-dynamodb-table/src/.checkov.yml
@@ -1,0 +1,15 @@
+# Checkov skip configuration for aws-dynamodb-table
+#
+# Checks that are hardcoded in Terraform (no need to skip — they will pass):
+#   CKV_AWS_28  - server_side_encryption.enabled = true
+#   CKV2_AWS_16 - point_in_time_recovery.enabled = true
+#   CKV2_AWS_118 - deletion_protection_enabled = true
+#
+# Muted checks with documented rationale:
+skip-check:
+  # CKV_AWS_119: DynamoDB table with customer-managed KMS key
+  # Rationale: AWS-managed SSE is enforced (CKV_AWS_28). Customer-managed KMS
+  # adds operational burden (key rotation, cross-account complexity) that is
+  # out of scope for this general-purpose bundle. Teams requiring CMK can fork
+  # this bundle and add the kms_master_key_id attribute.
+  - CKV_AWS_119

--- a/bundles/aws-dynamodb-table/src/artifacts.tf
+++ b/bundles/aws-dynamodb-table/src/artifacts.tf
@@ -1,0 +1,20 @@
+resource "massdriver_artifact" "table" {
+  field = "table"
+  name  = "DynamoDB ${var.table_name} (${var.md_metadata.name_prefix})"
+  artifact = jsonencode({
+    arn        = aws_dynamodb_table.main.arn
+    name       = aws_dynamodb_table.main.name
+    region     = var.region
+    stream_arn = var.enable_streams ? aws_dynamodb_table.main.stream_arn : ""
+    policies = [
+      {
+        id   = aws_iam_policy.read_only.arn
+        name = "Read Only"
+      },
+      {
+        id   = aws_iam_policy.read_write.arn
+        name = "Read / Write"
+      },
+    ]
+  })
+}

--- a/bundles/aws-dynamodb-table/src/main.tf
+++ b/bundles/aws-dynamodb-table/src/main.tf
@@ -1,0 +1,143 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    massdriver = {
+      source  = "massdriver-cloud/massdriver"
+      version = "~> 1.3"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+  assume_role {
+    role_arn    = var.aws_authentication.arn
+    external_id = try(var.aws_authentication.external_id, null)
+  }
+  default_tags {
+    tags = var.md_metadata.default_tags
+  }
+}
+
+locals {
+  # Only set range_key attributes when a range key is provided
+  has_range_key = var.range_key != null && var.range_key != ""
+
+  # Capacity units only matter in PROVISIONED mode; PAY_PER_REQUEST ignores them
+  is_provisioned = var.billing_mode == "PROVISIONED"
+
+  # Stream view type only matters when streams are enabled
+  stream_view_type = var.enable_streams ? var.stream_view_type : null
+}
+
+resource "aws_dynamodb_table" "main" {
+  name         = var.table_name
+  billing_mode = var.billing_mode
+  hash_key     = var.hash_key
+
+  # Provisioned capacity — ignored by DynamoDB when billing_mode = PAY_PER_REQUEST
+  read_capacity  = local.is_provisioned ? var.read_capacity : null
+  write_capacity = local.is_provisioned ? var.write_capacity : null
+
+  # Optional sort key
+  range_key = local.has_range_key ? var.range_key : null
+
+  # Partition key attribute definition
+  attribute {
+    name = var.hash_key
+    type = var.hash_key_type
+  }
+
+  # Sort key attribute definition (only when range key is provided)
+  dynamic "attribute" {
+    for_each = local.has_range_key ? [1] : []
+    content {
+      name = var.range_key
+      type = var.range_key_type
+    }
+  }
+
+  # Hardcoded compliance: server-side encryption with AWS-managed key (CKV_AWS_28)
+  server_side_encryption {
+    enabled = true
+  }
+
+  # Hardcoded compliance: point-in-time recovery (CKV_AWS_28 / CKV2_AWS_16)
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  # Hardcoded compliance: deletion protection prevents accidental table drops (CKV2_AWS_118)
+  deletion_protection_enabled = true
+
+  # DynamoDB Streams
+  stream_enabled   = var.enable_streams
+  stream_view_type = local.stream_view_type
+
+  lifecycle {
+    # Key schema, table name, and billing mode cannot be changed in-place —
+    # changing them would require a new table, so treat them as immutable here too.
+    ignore_changes = []
+  }
+}
+
+# IAM policy: read-only access
+resource "aws_iam_policy" "read_only" {
+  name        = "${var.table_name}-read-only"
+  description = "Read-only access to DynamoDB table ${var.table_name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:BatchGetItem",
+          "dynamodb:Query",
+          "dynamodb:Scan",
+          "dynamodb:DescribeTable",
+        ]
+        Resource = [
+          aws_dynamodb_table.main.arn,
+          "${aws_dynamodb_table.main.arn}/index/*",
+        ]
+      }
+    ]
+  })
+}
+
+# IAM policy: read-write access
+resource "aws_iam_policy" "read_write" {
+  name        = "${var.table_name}-read-write"
+  description = "Read-write access to DynamoDB table ${var.table_name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:BatchGetItem",
+          "dynamodb:Query",
+          "dynamodb:Scan",
+          "dynamodb:DescribeTable",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:BatchWriteItem",
+          "dynamodb:ConditionCheckItem",
+        ]
+        Resource = [
+          aws_dynamodb_table.main.arn,
+          "${aws_dynamodb_table.main.arn}/index/*",
+        ]
+      }
+    ]
+  })
+}

--- a/bundles/aws-dynamodb-table/src/variables.tf
+++ b/bundles/aws-dynamodb-table/src/variables.tf
@@ -1,0 +1,99 @@
+variable "region" {
+  type        = string
+  description = "AWS region where the DynamoDB table will be created."
+}
+
+variable "table_name" {
+  type        = string
+  description = "Name of the DynamoDB table."
+}
+
+variable "hash_key" {
+  type        = string
+  description = "Attribute name for the partition key."
+}
+
+variable "hash_key_type" {
+  type        = string
+  description = "Data type for the partition key: S (String), N (Number), or B (Binary)."
+  default     = "S"
+}
+
+variable "range_key" {
+  type        = string
+  description = "Optional attribute name for the sort key."
+  default     = null
+}
+
+variable "range_key_type" {
+  type        = string
+  description = "Data type for the sort key: S (String), N (Number), or B (Binary)."
+  default     = "S"
+}
+
+variable "billing_mode" {
+  type        = string
+  description = "PAY_PER_REQUEST or PROVISIONED billing mode."
+  default     = "PAY_PER_REQUEST"
+}
+
+variable "read_capacity" {
+  type        = number
+  description = "Provisioned read capacity units (PROVISIONED mode only)."
+  default     = 5
+}
+
+variable "write_capacity" {
+  type        = number
+  description = "Provisioned write capacity units (PROVISIONED mode only)."
+  default     = 5
+}
+
+variable "enable_streams" {
+  type        = bool
+  description = "Whether to enable DynamoDB Streams."
+  default     = false
+}
+
+variable "stream_view_type" {
+  type        = string
+  description = "What data is written to the stream when enabled."
+  default     = "NEW_AND_OLD_IMAGES"
+}
+
+variable "aws_authentication" {
+  type = object({
+    arn         = string
+    external_id = optional(string)
+  })
+  description = "AWS IAM role credentials."
+}
+
+variable "md_metadata" {
+  type = object({
+    default_tags = object({
+      managed-by  = string
+      md-manifest = string
+      md-package  = string
+      md-project  = string
+      md-target   = string
+    })
+    deployment = object({
+      id = string
+    })
+    name_prefix = string
+    observability = object({
+      alarm_webhook_url = string
+    })
+    package = object({
+      created_at             = string
+      deployment_enqueued_at = string
+      previous_status        = string
+      updated_at             = string
+    })
+    target = object({
+      contact_email = string
+    })
+  })
+  description = "Massdriver metadata injected at deploy time."
+}


### PR DESCRIPTION
One shot DynamoDB Self-Service OpenTofu bundle with Checkov compliance via Massdriver Agentic Harness + Claude Code

```
/massdriver:develop Create an "aws-dynamodb-table" module with a fairly simple interface for managing a table. Make dangerous-to-change fields immutable, hard code most compliance recommendations from the Massdriver provisioner. Note, nothing in this git repo has been published besides the AWS platform.
```