### PR TITLE
Add per-bundle README.md for registry display

### DIFF
--- a/bundles/application/README.md
+++ b/bundles/application/README.md
@@ -1,0 +1,24 @@
+# Application
+
+A containerized application — image, replica count, domain, CPU/memory limits, log level — wired to a network, a Postgres database, and (optionally) a bucket.
+
+> [!NOTE]
+> This is a **placeholder bundle**. It ships with a complete schema and a stub `random_pet` IaC so you can poke at the developer experience on the Massdriver canvas before writing any real Terraform/OpenTofu. Once the shape feels right, swap the stub for your real deployment module (Helm chart, Kubernetes manifests, ECS task, Cloud Run service — whatever you run).
+
+## What it shows
+
+This bundle is a worked example of the four things every bundle in the catalog brings together:
+
+- **Self-service experience** — labelled `oneOf` dropdowns for `environment` and `log_level`, Kubernetes-style `cpu_limit` / `memory_limit` enums, an `image` regex that rejects `:latest` (must be `image:tag` or `image@digest`), and `$md.enum` pickers for `database_policy` / `bucket_policy` that populate from the linked resources' `.policies` arrays.
+- **Operator guide** (`operator.md`) — a 2am runbook templated with the live image tag, replica count, domain, and resolved database/bucket connection info. Open it from the instance's runbook tab in the UI.
+- **Compliance** — a full `app:` block: `app.envs` lifts connection values into env vars with JQ (`DATABASE_HOST`, `DATABASE_URL`, `BUCKET_NAME` with a `// ""` fallback when no bucket is linked); `app.secrets` declares `JWT_SECRET` (required — UI blocks deploy until it's set), plus optional `SENTRY_DSN` and `GOOGLE_OAUTH_CLIENT_SECRET`. Three `massdriver_instance_alarm` definitions: `Pod Restart Rate`, `5xx Error Rate`, `p95 Latency`.
+- **IaC code** (`src/`) — a placeholder Terraform/OpenTofu module that wires `params` and all three `connections` (network, postgres, optional bucket) into `massdriver_resource` outputs. Replace it with your real deployment module.
+
+## Customize it
+
+1. Edit `massdriver.yaml` — match the params to your real deployment module's inputs (image pull secrets, sidecar containers, autoscaling, etc.) and adjust the `connections` block to whatever your app actually depends on.
+2. Rewrite `src/` to be your real Terraform/OpenTofu / Helm chart. `_massdriver_variables.tf` regenerates from your params + connections on every `mass bundle build`, so the schema and the variables stay in sync.
+3. Update `operator.md` with your team's actual runbook — restart loops, rollback procedure, traffic-shifting, on-call escalation.
+4. Tune the alarm definitions in `src/alarms.tf` to thresholds your team will actually wake up for.
+
+See the [catalog README](../../README.md) and [Bundle YAML Spec](https://docs.massdriver.cloud/guides/bundle-yaml-spec) for more.

--- a/bundles/bucket/README.md
+++ b/bundles/bucket/README.md
@@ -1,0 +1,24 @@
+# Bucket
+
+An object-storage bucket with access levels, versioning, lifecycle rules, CORS, and optional object lock. No upstream connections.
+
+> [!NOTE]
+> This is a **placeholder bundle**. It ships with a complete schema and a stub `random_pet` IaC so you can poke at the developer experience on the Massdriver canvas before writing any real Terraform/OpenTofu. Once the shape feels right, swap the stub for your real bucket module.
+
+## What it shows
+
+This bundle is a worked example of the four things every bundle in the catalog brings together:
+
+- **Self-service experience** — `access_level` as a labelled `oneOf` (so "Public Read+Write — rarely safe" is spelled out in the dropdown, not hidden behind an enum value), a re-orderable `lifecycle_rules` array (max 8, unique items) with per-rule storage class, CORS-origin URL pattern validation, and a conditional block that requires `object_lock_retention_days` + `versioning_enabled` whenever object lock is turned on.
+- **Operator guide** (`operator.md`) — a 2am runbook templated with the live bucket name, access level, versioning state, and active lifecycle rules. Open it from the instance's runbook tab in the UI.
+- **Compliance** — `$md.immutable: true` on `object_lock` (a one-way switch you can never undo by accident), public-access defaults that nudge toward private, and two `massdriver_instance_alarm` definitions (`5xx Error Rate`, conditional `Anonymous Access Anomaly` that fires only on private buckets).
+- **IaC code** (`src/`) — a placeholder Terraform/OpenTofu module that wires `params` into `massdriver_resource` outputs. Replace it with your real bucket module (S3, GCS, Azure Blob, MinIO, whatever you run).
+
+## Customize it
+
+1. Edit `massdriver.yaml` — match the params to your real bucket module's inputs (region, KMS keys, replication targets, etc.).
+2. Rewrite `src/` to be your real Terraform/OpenTofu. `_massdriver_variables.tf` regenerates from your params + connections on every `mass bundle build`, so the schema and the variables stay in sync.
+3. Update `operator.md` with your team's actual runbook — public-access incident response, lifecycle policy debugging, restore-from-versioning procedure.
+4. Tune the alarm definitions in `src/alarms.tf` to thresholds your team will actually wake up for.
+
+See the [catalog README](../../README.md) and [Bundle YAML Spec](https://docs.massdriver.cloud/guides/bundle-yaml-spec) for more.

--- a/bundles/mysql/README.md
+++ b/bundles/mysql/README.md
@@ -1,0 +1,24 @@
+# MySQL
+
+A MySQL instance with sizing, HA, character set, and slow-query controls. Depends on a `network`.
+
+> [!NOTE]
+> This is a **placeholder bundle**. It ships with a complete schema and a stub `random_pet` IaC so you can poke at the developer experience on the Massdriver canvas before writing any real Terraform/OpenTofu. Once the shape feels right, swap the stub for your real database module.
+
+## What it shows
+
+This bundle is a worked example of the four things every bundle in the catalog brings together:
+
+- **Self-service experience** — t-shirt sized instances (`xs` → `xl`), an `$md.enum` subnet picker populated from the linked network, immutable `character_set` / `collation` dropdowns, a 32-char-capped `username` (MySQL's limit), and a conditional `slow_query_log_long_query_time_seconds` that appears only when slow query logging is on.
+- **Operator guide** (`operator.md`) — a 2am runbook templated with the live host, port, character set, and slow-query settings. Open it from the instance's runbook tab in the UI.
+- **Compliance** — immutability on `username` / `character_set` / `collation`, `$md.copyable: false` so credentials don't carry into cloned environments, `$md.sensitive: true` on the password output (masked in the UI and audit-logged on download), and three `massdriver_instance_alarm` definitions (`Storage 80% Full`, conditional `Slow Query Rate`, conditional `Replication Lag`).
+- **IaC code** (`src/`) — a placeholder Terraform/OpenTofu module that wires `params` and the upstream network `connection` into `massdriver_resource` outputs. Replace it with your real MySQL module (RDS, Cloud SQL, Azure Database, self-hosted, whatever you run).
+
+## Customize it
+
+1. Edit `massdriver.yaml` — match the params to your real MySQL module's inputs (engine version, parameter group, binlog settings, etc.).
+2. Rewrite `src/` to be your real Terraform/OpenTofu. `_massdriver_variables.tf` regenerates from your params + connections on every `mass bundle build`, so the schema and the variables stay in sync.
+3. Update `operator.md` with your team's actual runbook — failover steps, slow-query investigation, restore-from-backup procedure.
+4. Tune the alarm definitions in `src/alarms.tf` to thresholds your team will actually wake up for.
+
+See the [catalog README](../../README.md) and [Bundle YAML Spec](https://docs.massdriver.cloud/guides/bundle-yaml-spec) for more.

--- a/bundles/network/README.md
+++ b/bundles/network/README.md
@@ -1,0 +1,24 @@
+# Network
+
+A virtual network with subnets, optional flow-log retention, and DNS configuration.
+
+> [!NOTE]
+> This is a **placeholder bundle**. It ships with a complete schema and a stub `random_pet` IaC so you can poke at the developer experience on the Massdriver canvas before writing any real Terraform/OpenTofu. Once the shape feels right, swap the stub for your real network module.
+
+## What it shows
+
+This bundle is a worked example of the four things every bundle in the catalog brings together:
+
+- **Self-service experience** — the params schema (CIDR, subnets, flow logs, DNS servers) is what your developers will fill out. Try the Small / Medium / Large presets, the conditional `flow_log_retention_days` field, and the immutable `cidr`.
+- **Operator guide** (`operator.md`) — a 2am runbook templated with the live network's CIDR, subnet table, and flow-log settings. Open it from the instance's runbook tab in the UI.
+- **Compliance** — two `massdriver_instance_alarm` definitions (`Egress Throughput Anomaly`, `NAT Port Exhaustion`) and immutability markers on fields that should never change post-deploy.
+- **IaC code** (`src/`) — a placeholder Terraform/OpenTofu module that wires `params` and `connections` into `massdriver_resource` outputs. Replace it with your real network module.
+
+## Customize it
+
+1. Edit `massdriver.yaml` — adjust the params schema to match the inputs your network module actually takes (region, peering, transit gateway IDs, etc.).
+2. Rewrite `src/` to be your real Terraform/OpenTofu. `_massdriver_variables.tf` regenerates from your params + connections on every `mass bundle build`, so the schema and the variables stay in sync.
+3. Update `operator.md` with your team's actual runbook steps — re-IP playbook, NAT exhaustion fix, on-call escalation.
+4. Tune the alarm definitions in `src/alarms.tf` to thresholds your team will actually wake up for.
+
+See the [catalog README](../../README.md) and [Bundle YAML Spec](https://docs.massdriver.cloud/guides/bundle-yaml-spec) for more.

--- a/bundles/postgres/README.md
+++ b/bundles/postgres/README.md
@@ -1,0 +1,24 @@
+# PostgreSQL
+
+A PostgreSQL instance with sizing, HA, and per-environment retention policy. Depends on a `network`.
+
+> [!NOTE]
+> This is a **placeholder bundle**. It ships with a complete schema and a stub `random_pet` IaC so you can poke at the developer experience on the Massdriver canvas before writing any real Terraform/OpenTofu. Once the shape feels right, swap the stub for your real database module.
+
+## What it shows
+
+This bundle is a worked example of the four things every bundle in the catalog brings together:
+
+- **Self-service experience** — t-shirt sized instances (`xs` → `xl`), a Postgres version dropdown with end-of-life labels, an `$md.enum` subnet picker populated from the linked network, conditional multi-AZ when HA is on, and storage sizing in 10 GB increments.
+- **Operator guide** (`operator.md`) — a 2am runbook templated with the live host, port, connection count, and HA topology. Open it from the instance's runbook tab in the UI.
+- **Compliance** — immutability on `username`, `$md.copyable: false` so credentials don't carry into cloned environments, `$md.sensitive: true` on the password output (masked in the UI and audit-logged on download), and three `massdriver_instance_alarm` definitions (`High Connections`, `Storage 80% Full`, conditional `Replication Lag`).
+- **IaC code** (`src/`) — a placeholder Terraform/OpenTofu module that wires `params` and the upstream network `connection` into `massdriver_resource` outputs. Replace it with your real Postgres module (RDS, Cloud SQL, Azure Database, self-hosted, whatever you run).
+
+## Customize it
+
+1. Edit `massdriver.yaml` — match the params to your real Postgres module's inputs (engine version list, parameter group, IAM auth, etc.).
+2. Rewrite `src/` to be your real Terraform/OpenTofu. `_massdriver_variables.tf` regenerates from your params + connections on every `mass bundle build`, so the schema and the variables stay in sync.
+3. Update `operator.md` with your team's actual runbook — failover steps, connection-storm playbook, restore-from-backup procedure.
+4. Tune the alarm definitions in `src/alarms.tf` to thresholds your team will actually wake up for.
+
+See the [catalog README](../../README.md) and [Bundle YAML Spec](https://docs.massdriver.cloud/guides/bundle-yaml-spec) for more.


### PR DESCRIPTION
## Summary
- Adds a brief `README.md` to each of the 5 catalog bundles (`network`, `postgres`, `mysql`, `bucket`, `application`).
- READMEs render in the Massdriver registry the same way GitHub renders a repo README — this gives anyone browsing the registry a quick orientation on each bundle.
- Each README frames the bundle as a **placeholder template** (model first, implement later) and walks through the four features the catalog's tour section calls out: self-service experience, operator guide, compliance, and IaC code. Closes with a short "Customize it" checklist.

## Test plan
- [ ] Browse to each bundle in the Massdriver registry and confirm the README renders.
- [ ] Verify links to the catalog root README and the Bundle YAML Spec resolve.
- [ ] Confirm dev versions publish cleanly via `mass bundle publish --development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)