### PR TITLE
Document preview.yaml and preview environments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,21 @@ make publish-platforms
 
 This compiles the `massdriver.yaml` definitions into `dist.json` artifacts for publishing.
 
+### 📄 `preview.yaml`
+
+**Preview environments** are short-lived environments forked from a base environment (typically `production` or `staging`) so you can stand up a full stack for a pull request, a demo, or a one-off experiment without hand-wiring every instance. Massdriver clones the canvas, then applies the overrides you declare in `preview.yaml` — pinning specific bundle versions, swapping in cheaper instance sizes, scoping secrets, and templating values with environment variables like `${GITHUB_PR}`.
+
+The `preview.yaml` at the repo root is a working example you can adapt:
+
+- **`project` / `baseEnvironment`** — which environment to fork from.
+- **`attributes`** — ABAC tags applied to the new environment (lifecycle, branch, region).
+- **`environmentDefaults`** — pin shared resources (e.g. a Kubernetes cluster) the preview should reuse instead of cloning.
+- **`instances`** — per-instance overrides for `version`, `params`, and `secrets`. Instances listed without overrides inherit from the fork; instances omitted entirely are still cloned from the parent.
+
+Use it from CI (typically a `pull_request` GitHub Action) with `mass preview deploy`, and tear it down on PR close with `mass preview decommission`.
+
+See the [Preview Environments workflow guide](https://docs.massdriver.cloud/workflows/preview) for the full CLI reference, CI examples, and the complete `preview.yaml` schema.
+
 ## Tour of the Demo Bundles & Resource Types
 
 The bundles and resource types ship pre-wired with realistic shapes so you can poke at the UX on the canvas before writing any IaC. Below is a quick map of what's in each one and which `massdriver.yaml` features it showcases — useful when you want to find a working example of `$md.enum`, the `app:` block, conditional `dependencies`, etc.
@@ -498,6 +513,7 @@ This catalog is designed for a three-phase approach: model your architecture, im
 .
 ├── README.md                           # This file
 ├── Makefile                            # Automation for publishing
+├── preview.yaml                        # Preview environment fork config (see docs.massdriver.cloud/workflows/preview)
 ├── resource-types/                     # Resource type contracts (formerly artifact definitions)
 │   ├── application/
 │   │   └── massdriver.yaml

--- a/README.md
+++ b/README.md
@@ -254,7 +254,18 @@ The `preview.yaml` at the repo root is a working example you can adapt:
 - **`environmentDefaults`** — pin shared resources (e.g. a Kubernetes cluster) the preview should reuse instead of cloning.
 - **`instances`** — per-instance overrides for `version`, `params`, and `secrets`. Instances listed without overrides inherit from the fork; instances omitted entirely are still cloned from the parent.
 
-Use it from CI (typically a `pull_request` GitHub Action) with `mass preview deploy`, and tear it down on PR close with `mass preview decommission`.
+Use it from CI (typically a `pull_request` GitHub Action) to fork the environment:
+
+```bash
+mass environment preview "pr${GITHUB_PR}" -f preview.yaml
+```
+
+Then on PR close, decommission and delete it:
+
+```bash
+mass environment decommission "pr${GITHUB_PR}" --follow
+mass environment delete "pr${GITHUB_PR}"
+```
 
 See the [Preview Environments workflow guide](https://docs.massdriver.cloud/workflows/preview) for the full CLI reference, CI examples, and the complete `preview.yaml` schema.
 


### PR DESCRIPTION
## Summary
- Adds a `preview.yaml` subsection under **What's Inside** explaining preview environment forks, the key fields in `preview.yaml`, and the CI usage pattern with `mass preview deploy` / `mass preview decommission`.
- Links to [docs.massdriver.cloud/workflows/preview](https://docs.massdriver.cloud/workflows/preview) for the full CLI reference and schema.
- Adds `preview.yaml` to the Repository Structure tree.

## Test plan
- [ ] Render README on GitHub and confirm the new section appears between **platforms** and **Tour of the Demo Bundles & Resource Types**.
- [ ] Verify the docs link resolves to the Preview Environments workflow guide.
- [ ] Confirm the Repository Structure tree still renders correctly with the added `preview.yaml` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)