### PR TITLE
Require OCI repositories for resource types as well as bundles

### DIFF
--- a/.github/workflows/publish-bundles-dev.yml.example
+++ b/.github/workflows/publish-bundles-dev.yml.example
@@ -50,7 +50,7 @@ jobs:
           for bundle_name in $CHANGED_BUNDLES; do
             bundle_dir="bundles/$bundle_name"
             echo "Ensuring bundle repository exists for $bundle_name..."
-            mass bundle create "$bundle_name" 2>&1 || true
+            mass repository create "$bundle_name" -t bundle 2>&1 || true
             echo "Publishing dev release for: $bundle_name..."
             mass bundle publish --development --bundle-directory "$bundle_dir"
           done

--- a/.github/workflows/publish-bundles.yml
+++ b/.github/workflows/publish-bundles.yml
@@ -20,18 +20,19 @@ jobs:
       - name: Install Massdriver CLI
         uses: massdriver-cloud/actions/setup@v6
       - name: Publish All Bundles
-        # Massdriver v2 requires an OCI repository to exist before publishing.
-        # `mass bundle create` is idempotent against the API on a name match,
-        # so we attempt creation first and continue if it already exists.
+        # Massdriver v2 requires an OCI repository (named exactly after the
+        # bundle) to exist before publishing. `mass repository create` is
+        # idempotent against the API on a name match, so we attempt creation
+        # first and continue if it already exists.
         # We keep stderr on stdout so auth/permission failures stay visible in
         # CI logs — `mass bundle publish` will then surface the real failure.
-        # Bundles that need custom attributes (e.g. -a owner=data) should be
-        # created out-of-band once; see the README for guidance.
+        # Repositories that need custom attributes (e.g. -a owner=data) should
+        # be created out-of-band once; see the README for guidance.
         run: |
           for bundle_dir in bundles/*/; do
             bundle_name=$(basename "$bundle_dir")
             echo "Ensuring bundle repository exists for $bundle_name..."
-            mass bundle create "$bundle_name" 2>&1 || true
+            mass repository create "$bundle_name" -t bundle 2>&1 || true
             echo "Publishing bundle: $bundle_name..."
             mass bundle publish --bundle-directory "$bundle_dir"
           done

--- a/.github/workflows/publish-platforms.yml
+++ b/.github/workflows/publish-platforms.yml
@@ -25,10 +25,16 @@ jobs:
       - name: Publish Enabled Platforms
         # Platforms are resource types that model cloud-provider credentials.
         # We split them out from `resource-types/` for discoverability.
+        # Massdriver v2 requires an OCI repository (named exactly after the
+        # resource type declared in the platform's massdriver.yaml, e.g.
+        # aws-iam-role) to exist before publish; creation is idempotent.
         run: |
           for platform in $ENABLED_PLATFORMS; do
             platform_file="platforms/${platform}/massdriver.yaml"
             if [ -f "$platform_file" ]; then
+              name=$(grep -m1 '^name:' "$platform_file" | awk '{print $2}')
+              echo "Ensuring resource-type repository exists for $name..."
+              mass repository create "$name" -t resource-type 2>&1 || true
               echo "Publishing platform: $platform..."
               mass resource-type publish "$platform_file"
             else

--- a/.github/workflows/publish-resource-types.yml
+++ b/.github/workflows/publish-resource-types.yml
@@ -20,9 +20,15 @@ jobs:
       - name: Install Massdriver CLI
         uses: massdriver-cloud/actions/setup@v6
       - name: Publish All Resource Types
+        # Massdriver v2 requires an OCI repository (named exactly after the
+        # resource type) to exist before publish. `mass repository create` is
+        # idempotent against the API on a name match, so we attempt creation
+        # first and continue if it already exists.
         run: |
           for dir in resource-types/*/; do
             name=$(basename "$dir")
+            echo "Ensuring resource-type repository exists for $name..."
+            mass repository create "$name" -t resource-type 2>&1 || true
             echo "Publishing resource type $name..."
             mass resource-type publish "${dir}massdriver.yaml"
           done

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all publish-all publish-bundles publish-resource-types publish-platforms create-bundle-repos build-bundles validate-bundles clean clean-variables clean-lock clean-terraform clean-state clean-schemas help
+.PHONY: all publish-all publish-bundles publish-resource-types publish-platforms create-repos build-bundles validate-bundles clean clean-variables clean-lock clean-terraform clean-state clean-schemas help
 
 # Enabled platforms - edit this list to enable additional platforms
 # Available: aws, gcp, azure, kubernetes, vercel, snowflake, ovh, upcloud, scaleway, digitalocean
@@ -15,7 +15,7 @@ help:
 	@echo "  make all                    - Clean, publish resource types, build, validate and publish bundles"
 	@echo "  make publish-platforms      - Publish platform credential resource types"
 	@echo "  make publish-resource-types - Publish resource types"
-	@echo "  make create-bundle-repos    - Create OCI repositories for each bundle (idempotent)"
+	@echo "  make create-repos           - Create OCI repositories for all bundles + resource types (idempotent)"
 	@echo "  make build-bundles          - Build all bundles (generate schemas)"
 	@echo "  make validate-bundles       - Initialize and validate all bundles with OpenTofu"
 	@echo "  make publish-bundles        - Publish all bundles to Massdriver"
@@ -39,35 +39,47 @@ help:
 all:
 	@echo "This will clean, publish resource types, build, validate and publish all bundles."
 	@read -p "Continue? (y/N): " confirm && [ "$$confirm" = "y" ] || [ "$$confirm" = "Y" ] || (echo "Aborted." && exit 1)
-	@$(MAKE) clean publish-resource-types create-bundle-repos build-bundles validate-bundles publish-bundles
+	@$(MAKE) clean create-repos publish-resource-types build-bundles validate-bundles publish-bundles
 
-publish-all: publish-platforms publish-resource-types create-bundle-repos publish-bundles
+publish-all: create-repos publish-platforms publish-resource-types publish-bundles
 	@echo "Successfully published all platforms, resource types, and bundles!"
 
-publish-platforms:
+publish-platforms: create-repos
 	@for platform in $(PLATFORMS); do \
 		echo "Publishing platform $$platform..."; \
 		mass resource-type publish platforms/$$platform/massdriver.yaml; \
 	done
 
-# Massdriver v2 requires an OCI repository to exist before `mass bundle publish`.
-# `mass bundle create` is safe to re-run — if the repository already exists the
-# command exits non-zero, which we ignore. We keep stderr on the console so auth
-# or network errors stay visible. If your bundle needs custom attributes, run
-# `mass bundle create <name> -a key=value` once by hand instead.
-create-bundle-repos:
+# Massdriver v2 publishes into OCI repositories, and the repository must exist
+# before publish — for BUNDLES and RESOURCE TYPES alike (platforms are resource
+# types too). A repository is named exactly after the bundle / resource type it
+# holds, and all repositories share one namespace, so names cannot collide.
+# `mass repository create` is safe to re-run — if the repository already exists
+# the command exits non-zero, which we ignore. We keep stderr on the console so
+# auth or network errors stay visible. If a repository needs custom attributes,
+# run `mass repository create <name> -t <type> -a key=value` once by hand.
+create-repos:
+	@for rt in $(RESOURCE_TYPES); do \
+		echo "Ensuring resource-type repository exists for $$rt..."; \
+		mass repository create $$rt -t resource-type 2>&1 || true; \
+	done
+	@for platform in $(PLATFORMS); do \
+		name=$$(grep -m1 '^name:' platforms/$$platform/massdriver.yaml | awk '{print $$2}'); \
+		echo "Ensuring resource-type repository exists for $$name..."; \
+		mass repository create $$name -t resource-type 2>&1 || true; \
+	done
 	@for bundle in $(BUNDLES); do \
 		echo "Ensuring bundle repository exists for $$bundle..."; \
-		mass bundle create $$bundle 2>&1 || true; \
+		mass repository create $$bundle -t bundle 2>&1 || true; \
 	done
 
-publish-bundles: clean-lock create-bundle-repos build-bundles validate-bundles
+publish-bundles: clean-lock create-repos build-bundles validate-bundles
 	@for bundle in $(BUNDLES); do \
 		echo "Publishing $$bundle..."; \
 		mass bundle publish --bundle-directory bundles/$$bundle; \
 	done
 
-publish-resource-types:
+publish-resource-types: create-repos
 	@for rt in $(RESOURCE_TYPES); do \
 		echo "Publishing resource type $$rt..."; \
 		mass resource-type publish resource-types/$$rt/massdriver.yaml; \

--- a/README.md
+++ b/README.md
@@ -383,20 +383,22 @@ Each resource type ships per-source form-fill walkthroughs that render alongside
    - `MASSDRIVER_URL` - The API URL of your self-hosted Massdriver instance (e.g., `https://api.massdriver.yourdomain.com`). If not set, defaults to `https://api.massdriver.cloud`.
 
    Once configured, any push to the `main` branch will automatically:
-   - Publish all resource types in `resource-types/` (and any enabled platforms in `platforms/`)
+   - Ensure each resource type's OCI repository exists, then publish all resource types in `resource-types/` (and any enabled platforms in `platforms/`)
    - Ensure each bundle's OCI repository exists, then build and publish all bundles in `bundles/`
 
    > [!TIP]
    > To publish snapshot/dev versions on every PR push, enable [`publish-bundles-dev.yml.example`](./.github/workflows/publish-bundles-dev.yml.example) by renaming it. It runs `mass bundle publish --development` against any bundles changed in the PR.
 
-#### Bundle OCI repositories
+#### OCI repositories
 
-In Massdriver v2, every bundle is published into its own OCI repository, and **the repository must exist before `mass bundle publish` will succeed**. The CI workflow handles this automatically — it calls `mass bundle create <name>` for each bundle on every run and ignores the "already exists" error. Locally, `make create-bundle-repos` does the same thing.
+In Massdriver v2, every **bundle and every resource type** (platforms included) is published into its own OCI repository, and **the repository must exist before publish will succeed**. A repository is named exactly after the bundle or resource type it holds, and all repositories share a single namespace — so a bundle and a resource type cannot use the same name.
 
-If a bundle needs custom attributes (for example, `-a owner=data,service=database`), the workflow can't infer them. Create those repositories once by hand:
+The CI workflows handle creation automatically — they call `mass repository create <name> -t bundle` (or `-t resource-type`) before each publish and ignore the "already exists" error. Locally, `make create-repos` does the same thing for everything in the catalog.
+
+If a repository needs custom attributes (for example, `-a owner=data,service=database`), the workflow can't infer them. Create those repositories once by hand:
 
 ```bash
-mass bundle create my-bundle -a owner=data,service=database
+mass repository create my-bundle -t bundle -a owner=data,service=database
 ```
 
 After that, normal pushes will keep publishing into the same repo.
@@ -405,7 +407,7 @@ After that, normal pushes will keep publishing into the same repo.
 
 The service account behind `MASSDRIVER_API_KEY` needs to be able to:
 
-- **Create OCI repositories** — required for the idempotent `mass bundle create` step.
+- **Create OCI repositories** — required for the idempotent `mass repository create` step.
 - **Publish to OCI repositories** — required for `mass bundle publish`.
 - **Publish resource types** — required for `mass resource-type publish` (used for both `resource-types/` and `platforms/`).
 
@@ -468,8 +470,8 @@ make all
 
    This command will:
    - Clean up any previous build artifacts
+   - Ensure an OCI repository exists for every resource type and bundle (`make create-repos`)
    - Publish resource types to your Massdriver instance
-   - Ensure an OCI repository exists for each bundle (`make create-bundle-repos`)
    - Build all bundles (generates schema JSON files from `massdriver.yaml`)
    - Validate all bundles with OpenTofu, Helm, etc.
    - Publish all bundles to your Massdriver instance using your default `mass` CLI profile


### PR DESCRIPTION
## Summary

New platform requirement: **every bundle AND every resource type (platforms included) must have an OCI repository created before publish.** Repositories are named exactly after the bundle/resource type and share a single namespace, so names cannot collide.

- **Makefile** — `create-bundle-repos` is now `create-repos`: it creates repositories for all resource types, enabled platforms (name read from each `massdriver.yaml`), and bundles via `mass repository create <name> -t bundle|resource-type`. All publish targets depend on it.
- **CI** — `publish-resource-types.yml` and `publish-platforms.yml` now create the resource-type repository before publishing; `publish-bundles.yml` and `publish-bundles-dev.yml.example` switch from `mass bundle create` to `mass repository create -t bundle`. Creation stays idempotent (`|| true` on the already-exists error), keeping stderr visible for real auth failures.
- **README** — "Bundle OCI repositories" generalized to all repository types, with the shared-namespace rule documented and the custom-attributes escape hatch updated to the new command.

No behavior change for repos that already exist — creation is attempted and skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)